### PR TITLE
Adding cmd-line executable jar source for template-tester, samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+target

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,14 +1,14 @@
 # Template Test Utilities
 
-This provides couple of simple utilities for quickly testing a template against content you provide.
+The tools here provides couple of simple utilities for quickly testing a template against content you provide without installing the Akana FreeMarker Activity for the API Gateway.
 
 You will need to download the [freemarker jar](http://freemarker.org/freemarkerdownload.html), and [Apache Commons IO](https://commons.apache.org/proper/commons-io/download_io.cgi) and make sure these jars are in your project build path.
 
 The tools will read templates and files from a specified directory - you will need to change this.
 
-TestXML.java will read a template called testxml.ftl and a source file called test.xml and will output the results.
+* `TestXML.java` will read a template called `testxml.ftl` and a source file called `test.xml` and will output the results.
 
-TestJSON.java will read a template called testjson.ftl and a source file called test.json and will output the results.
+*  `TestJSON.java` will read a template called `testjson.ftl` and a source file called `test.json` and will output the results.
 
-Both tools mimic the helper methods creating a top-level object in the data model called message and adding contentAsXml and contentAsString methods appropriately.
+Both tools mimic the Akana FreeMarker Activity helper methods creating a top-level object in the data model called message and adding `contentAsXml` and `contentAsString` methods appropriately.
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,6 +2,54 @@
 
 The tools here provides couple of simple utilities for quickly testing a template against content you provide without installing the Akana FreeMarker Activity for the API Gateway.
 
+The tools mimic the Akana FreeMarker Activity helper methods creating a top-level object in the data model called `message` and adding `contentAsXml` and `contentAsString` methods appropriately.
+
+## Executable jar
+
+The tools jar can be obtained from the releases section.
+
+### Usage
+
+	usage: template-tester <FTL_FILE> <MODEL_FILE>
+	 -content <contenttype>   content type of model
+	 -help                    print this message
+
+Example
+
+	java -jar template-tester-0.0.1.jar samples/sample2.1.ftl samples/sample2_data.xml
+
+With the `-content` flag, you can specify the input type of the data model file.
+
+	java -jar template-tester-0.0.1.jar -content json samples/sample4.ftl samples/sample4_data.json
+
+
+Example run:
+
+	java -jar template-tester-0.0.1.jar -content json samples/sample4.ftl samples/sample4_data.json
+
+	Processing ftl   : samples/sample4.ftl
+	  with data model: samples/sample4_data.json
+	with content-type: json
+	{
+	  "name" : [
+			"Dinosaur",
+			"Rover",
+			"Fido",
+			"Brontosuarus"  ]
+	}
+
+### Build
+
+To build an executable jar, use maven:
+
+	mvn clean compile assembly:single
+
+The output will show up in the `target` directory.
+
+## Standalone classes
+
+These java source files are useful when using in an IDE, like Eclipse.
+
 You will need to download the [freemarker jar](http://freemarker.org/freemarkerdownload.html), and [Apache Commons IO](https://commons.apache.org/proper/commons-io/download_io.cgi) and make sure these jars are in your project build path.
 
 The tools will read templates and files from a specified directory - you will need to change this.
@@ -9,6 +57,4 @@ The tools will read templates and files from a specified directory - you will ne
 * `TestXML.java` will read a template called `testxml.ftl` and a source file called `test.xml` and will output the results.
 
 *  `TestJSON.java` will read a template called `testjson.ftl` and a source file called `test.json` and will output the results.
-
-Both tools mimic the Akana FreeMarker Activity helper methods creating a top-level object in the data model called message and adding `contentAsXml` and `contentAsString` methods appropriately.
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.akana.demo.freemarker</groupId>
+	<artifactId>template-tester</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>FreeMarker template tester</name>
+	<url>http://maven.apache.org</url>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>3.8.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.freemarker</groupId>
+			<artifactId>freemarker</artifactId>
+			<version>2.3.23</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>1.3.1</version>
+		</dependency>
+
+	</dependencies>
+	<description>Allows testing of FreeMarker ftl with optional data models.</description>
+	<organization>
+		<name>Akana, Inc.</name>
+		<url>http://www.akana.com</url>
+	</organization>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>com.akana.demo.freemarker.templatetester.App</mainClass>
+						</manifest>
+					</archive>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tools/samples/sample1.ftl
+++ b/tools/samples/sample1.ftl
@@ -1,0 +1,2 @@
+<#assign m = message.contentAsString?eval>
+<name>${m.pet.name}</name>

--- a/tools/samples/sample1_data.json
+++ b/tools/samples/sample1_data.json
@@ -1,0 +1,7 @@
+{
+  "pet":
+    {
+      "name": "fido",
+      "type": "dog"
+    }
+}

--- a/tools/samples/sample2.1.ftl
+++ b/tools/samples/sample2.1.ftl
@@ -1,0 +1,2 @@
+<#ftl ns_prefixes={"br":"http://demo.akana.com/borrower"}>
+{ "result" : "${message.contentAsXml["br:add"]["br:borrower"]["br:last"]}" }

--- a/tools/samples/sample2.2.ftl
+++ b/tools/samples/sample2.2.ftl
@@ -1,0 +1,3 @@
+<#ftl ns_prefixes={"D":"http://demo.akana.com/borrower"}>
+<#assign xmlmsg = message.contentAsXml>
+{ "result" : "${xmlmsg.add.borrower.last}" }

--- a/tools/samples/sample2.3.ftl
+++ b/tools/samples/sample2.3.ftl
@@ -1,0 +1,5 @@
+<#ftl ns_prefixes={"D":"http://demo.akana.com/borrower"}>
+<#assign xmlmsg = message.contentAsXml>
+<br:borrower xmlns:br="http://demo.akana.com/borrower">
+	<br:last>${xmlmsg.add.borrower.last}</br:last>
+</br:borrower>

--- a/tools/samples/sample2_data.xml
+++ b/tools/samples/sample2_data.xml
@@ -1,0 +1,13 @@
+<br:add xmlns:br="http://demo.akana.com/borrower">
+   <br:borrower>
+      <br:id>111-11-1111</br:id>
+      <br:ssn>111-11-1111</br:ssn>
+      <br:city>Los Angeles</br:city>
+      <br:first>John</br:first>
+      <br:last>Smith</br:last>
+      <br:line1>12100 Wilshire Blvd</br:line1>
+      <br:phone>310-000-0000</br:phone>
+      <br:state>CA</br:state>
+      <br:zip>90025</br:zip>
+   </br:borrower>
+</br:add>

--- a/tools/samples/sample3.1.ftl
+++ b/tools/samples/sample3.1.ftl
@@ -1,0 +1,2 @@
+<#assign m = message.contentAsString?eval>
+{ "name" : "${m[0].name}" }

--- a/tools/samples/sample3.2.ftl
+++ b/tools/samples/sample3.2.ftl
@@ -1,0 +1,8 @@
+<#assign m = message.contentAsString?eval>
+{
+  "name" : [
+	<#list m as pet>
+		"${pet.name}"<#sep>,
+	</#list>
+  ]
+}

--- a/tools/samples/sample3_data.json
+++ b/tools/samples/sample3_data.json
@@ -1,0 +1,90 @@
+[
+    {
+        "category": {
+            "id": 100,
+            "name": "Dinosaur"
+        },
+        "name": "Tyrannosaurus",
+        "photoUrls": [
+            "http://en.wikipedia.org/wiki/Tyrannosaurus#/media/File:Tyrannosaurus_rex_mmartyniuk.png"
+        ],
+        "tags": [
+            {
+                "id": 100,
+                "name": "reptile"
+            },
+            {
+                "id": 101,
+                "name": "dinosaur"
+            }
+        ],
+        "status": "available",
+        "id": "100",
+        "href": "http://localhost:9900/things/petstore/100"
+    },
+    {
+        "category": {
+            "id": 200,
+            "name": "Dog"
+        },
+        "name": "Rover",
+        "photoUrls": [
+            "http://en.wikipedia.org/wiki/Tyrannosaurus#/media/File:Tyrannosaurus_rex_mmartyniuk.png"
+        ],
+        "tags": [
+            {
+                "id": 102,
+                "name": "mammal"
+            },
+            {
+                "id": 103,
+                "name": "dog"
+            }
+        ],
+        "status": "available",
+        "id": "101",
+        "href": "http://localhost:9900/things/petstore/101"
+    },
+    {
+        "category": {
+            "id": 200,
+            "name": "Dog"
+        },
+        "name": "Fido",
+        "photoUrls": [],
+        "tags": [
+            {
+                "id": 102,
+                "name": "mammal"
+            },
+            {
+                "id": 103,
+                "name": "dog"
+            }
+        ],
+        "status": "available",
+        "id": "102",
+        "href": "http://localhost:9900/things/petstore/102"
+    },
+    {
+        "id": "1433943941767",
+        "category": {
+            "id": 100,
+            "name": "Dinosaur"
+        },
+        "name": "Brontosuarus",
+        "photoUrls": [],
+        "tags": [
+            {
+                "id": 100,
+                "name": "reptile"
+            },
+            {
+                "id": 101,
+                "name": "dinosaur"
+            }
+        ],
+        "status": "sold",
+        "href": "http://localhost:9900/things/petstore/1433943941767"
+    }
+]

--- a/tools/samples/sample4.ftl
+++ b/tools/samples/sample4.ftl
@@ -1,0 +1,8 @@
+<#assign m = message.contentAsString?eval>
+{
+  "name" : [
+	<#list m as pet>
+		"<#if pet.name??>${pet.name}<#else>${pet.category.name}</#if>"<#sep>,
+	</#list>
+  ]
+}

--- a/tools/samples/sample4_data.json
+++ b/tools/samples/sample4_data.json
@@ -1,0 +1,89 @@
+[
+    {
+        "category": {
+            "id": 100,
+            "name": "Dinosaur"
+        },
+        "photoUrls": [
+            "http://en.wikipedia.org/wiki/Tyrannosaurus#/media/File:Tyrannosaurus_rex_mmartyniuk.png"
+        ],
+        "tags": [
+            {
+                "id": 100,
+                "name": "reptile"
+            },
+            {
+                "id": 101,
+                "name": "dinosaur"
+            }
+        ],
+        "status": "available",
+        "id": "100",
+        "href": "http://localhost:9900/things/petstore/100"
+    },
+    {
+        "category": {
+            "id": 200,
+            "name": "Dog"
+        },
+        "name": "Rover",
+        "photoUrls": [
+            "http://en.wikipedia.org/wiki/Tyrannosaurus#/media/File:Tyrannosaurus_rex_mmartyniuk.png"
+        ],
+        "tags": [
+            {
+                "id": 102,
+                "name": "mammal"
+            },
+            {
+                "id": 103,
+                "name": "dog"
+            }
+        ],
+        "status": "available",
+        "id": "101",
+        "href": "http://localhost:9900/things/petstore/101"
+    },
+    {
+        "category": {
+            "id": 200,
+            "name": "Dog"
+        },
+        "name": "Fido",
+        "photoUrls": [],
+        "tags": [
+            {
+                "id": 102,
+                "name": "mammal"
+            },
+            {
+                "id": 103,
+                "name": "dog"
+            }
+        ],
+        "status": "available",
+        "id": "102",
+        "href": "http://localhost:9900/things/petstore/102"
+    },
+    {
+        "id": "1433943941767",
+        "category": {
+            "id": 100,
+            "name": "Dinosaur"
+        },
+        "name": "Brontosuarus",
+        "photoUrls": [],
+        "tags": [
+            {
+                "id": 100,
+                "name": "reptile"
+            },
+            {
+                "id": 101,
+                "name": "dinosaur"
+            }
+        ],
+        "status": "sold",
+        "href": "http://localhost:9900/things/petstore/1433943941767"
+    }
+]

--- a/tools/src/main/java/com/akana/demo/freemarker/templatetester/App.java
+++ b/tools/src/main/java/com/akana/demo/freemarker/templatetester/App.java
@@ -1,0 +1,132 @@
+package com.akana.demo.freemarker.templatetester;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.io.FileUtils;
+import org.xml.sax.SAXException;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateExceptionHandler;
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+ 
+        final Options options = new Options();
+      
+        @SuppressWarnings("static-access")
+		Option optionContentType = OptionBuilder.withArgName("contenttype")
+        		.hasArg()
+        		.withDescription("content type of model")
+        		.create("content");
+        
+        Option optionHelp = new Option("help", "print this message");
+        
+        options.addOption(optionHelp);
+        options.addOption(optionContentType);
+        
+        CommandLineParser parser = new DefaultParser();
+       
+        CommandLine cmd;
+		try {
+			cmd = parser.parse(options, args);
+			
+			// Check for help flag
+			if (cmd.hasOption("help")) {
+				showHelp(options);
+				return;
+			}
+			
+			// Assign content type
+			String contentType = "text/xml";
+			if (cmd.hasOption("content")) {
+				contentType = cmd.getOptionValue("content");
+			} 
+			
+			String[] remainingArguments = cmd.getArgs();
+			if (remainingArguments.length < 2) {
+				showHelp(options);
+				return;
+			}
+			String ftlPath, dataPath = "none";
+			
+			ftlPath = remainingArguments[0];
+				dataPath = remainingArguments[1];
+			
+			System.out.println("Processing ftl   : " + ftlPath);
+			System.out.println("  with data model: " + dataPath);
+			System.out.println("with content-type: " + contentType);
+			
+			Configuration cfg = new Configuration(Configuration.VERSION_2_3_22);
+			cfg.setDirectoryForTemplateLoading(new File("."));
+			cfg.setDefaultEncoding("UTF-8");
+			cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+			
+			/* Create a data-model */
+			Map message = new HashMap();
+			if (contentType.contains("json")) {
+				message.put("contentAsString", 
+						FileUtils.readFileToString(new File(dataPath),
+						StandardCharsets.UTF_8));
+			} else {
+				message.put("contentAsXml", freemarker.ext.dom.NodeModel
+						.parse(new File(dataPath)));
+				
+			}
+			Map root = new HashMap();
+			root.put("message", message);
+
+			/* Get the template (uses cache internally) */
+			Template temp = cfg.getTemplate(ftlPath);
+
+			/* Merge data-model with template */
+			Writer out = new OutputStreamWriter(System.out);
+			temp.process(root, out);
+			
+		} catch (ParseException e) {
+			showHelp(options);
+			System.exit(1);
+		} catch (IOException e) {
+			System.out.println("Unable to parse ftl.");
+			e.printStackTrace();
+		} catch (SAXException e) {
+			System.out.println("XML parsing issue.");
+			e.printStackTrace();
+		} catch (ParserConfigurationException e) {
+			System.out.println("Unable to configure parser.");
+			e.printStackTrace();
+		} catch (TemplateException e) {
+			System.out.println("Unable to parse template.");
+			e.printStackTrace();
+		}
+        
+    }
+    
+    public static void showHelp(Options options) {
+    	HelpFormatter formatter = new HelpFormatter();
+		formatter.printHelp("template-tester <FTL_FILE> <MODEL_FILE>", options);
+    }
+}

--- a/tools/src/main/java/com/akana/demo/freemarker/templatetester/TestJSON.java
+++ b/tools/src/main/java/com/akana/demo/freemarker/templatetester/TestJSON.java
@@ -1,0 +1,47 @@
+package com.akana.demo.freemarker.templatetester;
+
+import freemarker.template.*;
+
+import java.util.*;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
+
+public class TestJSON {
+
+	public static void main(String[] args) throws Exception {
+
+		/* You should do this ONLY ONCE in the whole application life-cycle: */
+
+		/* Create and adjust the configuration singleton */
+		Configuration cfg = new Configuration(Configuration.VERSION_2_3_22);
+		cfg.setDirectoryForTemplateLoading(new File(
+				"/Users/ian.goldsmith/projects/freemarker"));
+		cfg.setDefaultEncoding("UTF-8");
+		cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+
+		/*
+		 * You usually do these for MULTIPLE TIMES in the application
+		 * life-cycle:
+		 */
+
+		/* Create a data-model */
+		Map message = new HashMap();
+		message.put("contentAsString", FileUtils.readFileToString(new File(
+				"/Users/ian.goldsmith/projects/freemarker/test.json"),
+				StandardCharsets.UTF_8));
+
+		Map root = new HashMap();
+		root.put("message", message);
+
+		/* Get the template (uses cache internally) */
+		Template temp = cfg.getTemplate("testjson.ftl");
+
+		/* Merge data-model with template */
+		Writer out = new OutputStreamWriter(System.out);
+		temp.process(root, out);
+		// Note: Depending on what `out` is, you may need to call `out.close()`.
+		// This is usually the case for file output, but not for servlet output.
+	}
+}

--- a/tools/src/main/java/com/akana/demo/freemarker/templatetester/TestXML.java
+++ b/tools/src/main/java/com/akana/demo/freemarker/templatetester/TestXML.java
@@ -1,0 +1,47 @@
+package com.akana.demo.freemarker.templatetester;
+
+import freemarker.template.*;
+
+import java.util.*;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
+
+public class TestXML {
+
+	public static void main(String[] args) throws Exception {
+
+		/* You should do this ONLY ONCE in the whole application life-cycle: */
+
+		/* Create and adjust the configuration singleton */
+		Configuration cfg = new Configuration(Configuration.VERSION_2_3_22);
+		cfg.setDirectoryForTemplateLoading(new File(
+				"/Users/ian.goldsmith/projects/freemarker"));
+		cfg.setDefaultEncoding("UTF-8");
+		cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+
+		/*
+		 * You usually do these for MULTIPLE TIMES in the application
+		 * life-cycle:
+		 */
+
+		/* Create a data-model */
+		Map message = new HashMap();
+		message.put("contentAsXml", freemarker.ext.dom.NodeModel
+				.parse(new File(
+						"/Users/ian.goldsmith/projects/freemarker/test.xml")));
+
+		Map root = new HashMap();
+		root.put("message", message);
+
+		/* Get the template (uses cache internally) */
+		Template temp = cfg.getTemplate("testxml.ftl");
+
+		/* Merge data-model with template */
+		Writer out = new OutputStreamWriter(System.out);
+		temp.process(root, out);
+		// Note: Depending on what `out` is, you may need to call `out.close()`.
+		// This is usually the case for file output, but not for servlet output.
+	}
+}

--- a/tools/src/test/java/com/akana/demo/freemarker/FreeMarkerTester/AppTest.java
+++ b/tools/src/test/java/com/akana/demo/freemarker/FreeMarkerTester/AppTest.java
@@ -1,0 +1,38 @@
+package com.akana.demo.freemarker.FreeMarkerTester;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}


### PR DESCRIPTION
Template tester jar command-line utility to supplement tools.
Samples from main readme as `.ftl` and `.xml`|`.json` files.
